### PR TITLE
Matching Page Layout

### DIFF
--- a/populating_DB.py
+++ b/populating_DB.py
@@ -38,6 +38,14 @@ populate_users = [
         "password": "password",
         "languages": ["English", "Mandarin"],
         "units": ["CITS3403", "CITS2200"]
+    },
+    {
+        "username": "bob",
+        "displayname": "bob",
+        "email": "bob@student.uwa.edu.au",
+        "password": "password",
+        "languages": ["English"],
+        "units": ["CITS3403", "CITS3002"]
     }
 ]
 
@@ -61,6 +69,10 @@ populated_user_answers = {
     "jordan": {
         "food_preferences": [4, 4, 3, 4, 3, 3, 4, 3, 4, 3],
         "social_energy": [3, 4, 3, 3, 3, 3, 2, 3, 2, 3]
+    },
+    "bob": {
+        "food_preferences": [4, 4, 3, 5, 3, 5, 4, 3, 4, 3],
+        "social_energy": [3, 4, 3, 3, 5, 3, 2, 3, 2, 3]
     }
 }
 
@@ -72,6 +84,9 @@ populated_profile_likes = [
     {"liker_username": "jordan", "liked_username": "sam"},
 
     {"liker_username": "charlie", "liked_username": "jordan"},
+
+    {"liker_username": "jordan", "liked_username": "bob"}
+    
 ]
 
 #This function then actually creates the users using our fake data

--- a/web/main/routes.py
+++ b/web/main/routes.py
@@ -51,3 +51,9 @@ def check_session():
 @require_login
 def notifications():
     return render_template('main/notifications.html')
+
+# Matching page (full list of matches)
+@main.route('/matching')
+@require_login
+def matching():
+    return render_template('main/matching.html')

--- a/web/main/routes.py
+++ b/web/main/routes.py
@@ -287,7 +287,32 @@ def notifications():
 @main.route('/matches')
 @require_login
 def matching():
-    return render_template('main/matching.html')
+    username = session.get("user")
+    user = User.query.filter_by(username=username).first()
+    threshold = request.args.get("threshold", default=10, type=int)
+ 
+    # Determine if the user has taken any quizzes
+    # (needed to distinguish "no quizzes done" from "no matches found")
+    has_quizzes = bool(get_answers_for_user(username))
+ 
+    # Get matches — will be [] if user hasn't taken quizzes OR no users meet threshold
+    matches = find_matches_for_user(username, threshold)
+    # Enrich each match dict with the full User object (same pattern as dashboard)
+    for i in range(len(matches)):
+        item = matches[i]
+        matchedUser = User.query.filter_by(username=item["username"]).first()
+        matches[i] = matchedUser
+ 
+    liked_usernames = get_liked_usernames(username)
+ 
+    return render_template(
+        'main/matching.html',
+        user=user,
+        matches=matches,
+        liked_usernames=liked_usernames,
+        has_quizzes=has_quizzes
+    )
+ 
 
 @main.app_errorhandler(404)
 def page_not_found(e):

--- a/web/main/routes.py
+++ b/web/main/routes.py
@@ -274,7 +274,7 @@ def notifications():
     return render_template("main/notifications.html", notifications=notifications)
 
 # Matching page (full list of matches)
-@main.route('/matching')
+@main.route('/matches')
 @require_login
 def matching():
     return render_template('main/matching.html')

--- a/web/main/routes.py
+++ b/web/main/routes.py
@@ -21,10 +21,9 @@ def landing_page():
 def dashboard():
     username = session.get("user")
     user = User.query.filter_by(username=username).first()
-    threshold = request.args.get("threshold", default=10, type=int)
 
     #This calls the matching logic in service.py
-    matches = find_matches_for_user(username, threshold)
+    matches = find_matches_for_user(username)
     for i in range(len(matches)):
         item = matches[i]
         matchedUser = User.query.filter_by(username=item["username"]).first()
@@ -289,14 +288,13 @@ def notifications():
 def matching():
     username = session.get("user")
     user = User.query.filter_by(username=username).first()
-    threshold = request.args.get("threshold", default=10, type=int)
  
     # Determine if the user has taken any quizzes
     # (needed to distinguish "no quizzes done" from "no matches found")
     has_quizzes = bool(get_answers_for_user(username))
  
     # Get matches — will be [] if user hasn't taken quizzes OR no users meet threshold
-    matches = find_matches_for_user(username, threshold)
+    matches = find_matches_for_user(username)
     # Enrich each match dict with the full User object (same pattern as dashboard)
     for i in range(len(matches)):
         item = matches[i]

--- a/web/static/css/dashboard.css
+++ b/web/static/css/dashboard.css
@@ -44,6 +44,7 @@
     background: white;
     font-size: 16px;
     font-family: inherit;
+    margin: 0;
     box-shadow: 0 2px 10px rgba(0,0,0,0.07);
 }
  
@@ -80,11 +81,14 @@
 }
  
 .slider-arrow {
+    width: auto;
     padding: 10px 14px;
     background: none;
     border: none;
     color: #F28A80;
     font-size: 22px;
+    cursor: pointer;
+    margin-top: 0;
     flex-shrink: 0;
     transition: transform 0.15s;
 }
@@ -159,10 +163,13 @@
 }
  
 .heart-btn {
+    width: auto;
     background: none;
     border: none;
     font-size: 20px;
     color: #ddd;
+    cursor: pointer;
+    margin-top: 0;
     padding: 0;
     align-self: flex-end;
     transition: color 0.2s;
@@ -170,7 +177,3 @@
  
 .heart-btn:hover { background: none; color: #F28A80; }
 .heart-btn.liked  { color: #F28A80; }
-/* base.css의 button/input 전역 스타일 override */
-.dashboard-content button { width: auto; margin-top: 0 ; }
-.dashboard-content input  { width: auto; margin: 0 ; }
-.search-btn  { width: auto; padding: 16px 32px; border-radius: 30px; }

--- a/web/static/css/dashboard.css
+++ b/web/static/css/dashboard.css
@@ -223,3 +223,24 @@
 .carousel-control-next {
     pointer-events: none;
 }
+
+
+/* Dashboard section header */
+.dash-section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.view-more-link {
+    color: #F28A80;
+    font-size: 15px;
+    font-weight: 700;
+    text-decoration: none;
+    transition: color 0.2s, transform 0.2s;
+}
+
+.view-more-link:hover {
+    color: #ED553D;
+    transform: translateX(2px);
+}

--- a/web/static/css/dashboard.css
+++ b/web/static/css/dashboard.css
@@ -79,15 +79,34 @@
     color: #555;
 }
 
+/* Dashboard section header */
+.dash-section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 90%;
+    align-self: center;
+}
+
+.view-more-link {
+    color: #F28A80;
+    font-size: 15px;
+    font-weight: 700;
+    text-decoration: none;
+    transition: color 0.2s, transform 0.2s;
+}
+
+.view-more-link:hover {
+    color: #ED553D;
+    transform: translateX(2px);
+}
+
 /* User card */
-
-
 .user-card {
     background: rgba(255, 255, 255, 0.74);
     border-radius: 20px;
     height: 100%;
     width: 100%;
-    table-layout: fixed;
     overflow: hidden;
     overflow-wrap: anywhere;
     padding: 20px;
@@ -98,10 +117,12 @@
     position: relative;
     text-align: left;
     white-space: initial;
+    text-decoration: none;
 }
 
 .user-card:hover {
     background: white;
+    text-decoration: none;
 }
 
 .user-card-wrap {
@@ -180,7 +201,7 @@
     color: #F28A80;
 }
 
-/* base.css의 button/input 전역 스타일 override */
+/* Override global button and input styles inside dashboard */
 .dashboard-content button {
     width: auto;
     margin-top: 0;
@@ -191,67 +212,168 @@
     margin: 0;
 }
 
-.search-btn {
-    width: auto;
-    padding: 16px 32px;
-    border-radius: 30px;
-}
-
-.carousel-inner {
-    mask-image: linear-gradient(to left, transparent 0%, black 3%, black 97%, transparent 100%);
-    display: flex;
-    text-align: center;
-    justify-content: space-evenly;
-}
-
-.carousel-item {
-    display: block;
-    margin: 20px;
-    flex: 0 0 calc((100% / 3) - 40px);
+/* Carousel layout */
+#dashRecommendedCarousel {
+    width: 90%;
+    align-self: center;
     position: relative;
+    overflow: visible;
 }
 
-
-@media screen and (max-width: 650px){
-    .carousel-item{
-    flex: 0 0 calc((100%) - 40px);
-}
-}
-
-
-
-.carousel-control-prev-icon{
-    margin-right: 200px;
-    pointer-events: all;
-}
-
-.carousel-control-next-icon {
-    margin-left: 200px;
-    pointer-events: all;
-}
-
-.carousel-control-prev,
-.carousel-control-next {
-    pointer-events: none;
-}
-
-
-/* Dashboard section header */
-.dash-section-header {
+/* Keep Bootstrap carousel visible while using multi-card layout */
+#dashRecommendedCarousel .carousel-inner {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
+    align-items: stretch;
+    justify-content: flex-start;
+    gap: 32px;
+    text-align: left;
+    overflow: hidden;
+    padding: 20px 0;
 }
 
-.view-more-link {
-    color: #F28A80;
-    font-size: 15px;
-    font-weight: 700;
-    text-decoration: none;
-    transition: color 0.2s, transform 0.2s;
+/* Show carousel items as cards instead of Bootstrap's single full-width slide */
+#dashRecommendedCarousel .carousel-item {
+    display: block;
+    flex: 0 0 calc((100% - 64px) / 3);
+    max-width: calc((100% - 64px) / 3);
+    margin: 0;
+    position: relative;
+    float: none;
+    transition: transform 0.4s ease;
 }
 
-.view-more-link:hover {
-    color: #ED553D;
-    transform: translateX(2px);
+/* Prevent Bootstrap from hiding inactive items */
+#dashRecommendedCarousel .carousel-item.active,
+#dashRecommendedCarousel .carousel-item-next,
+#dashRecommendedCarousel .carousel-item-prev {
+    display: block;
+}
+
+#dashRecommendedCarousel .carousel-item .user-card-wrap {
+    width: 100%;
+    height: 220px;
+}
+
+#dashRecommendedCarousel .carousel-item .user-card {
+    height: 100%;
+    min-height: 220px;
+    padding: 24px;
+}
+
+/* Carousel arrows */
+#dashRecommendedCarousel .carousel-control-prev,
+#dashRecommendedCarousel .carousel-control-next {
+    width: 42px;
+    height: 42px;
+    top: 50%;
+    transform: translateY(-50%);
+    opacity: 0.85;
+    pointer-events: auto;
+}
+
+#dashRecommendedCarousel .carousel-control-prev {
+    left: -58px;
+}
+
+#dashRecommendedCarousel .carousel-control-next {
+    right: -58px;
+}
+
+#dashRecommendedCarousel .carousel-control-prev-icon,
+#dashRecommendedCarousel .carousel-control-next-icon {
+    margin: 0;
+    pointer-events: all;
+}
+
+/* Responsive carousel */
+@media screen and (max-width: 900px) {
+    #dashRecommendedCarousel .carousel-inner {
+        gap: 32px;
+    }
+
+    #dashRecommendedCarousel .carousel-item {
+        flex: 0 0 calc((100% - 32px) / 2);
+        max-width: calc((100% - 32px) / 2);
+    }
+
+    #dashRecommendedCarousel .carousel-item .user-card-wrap {
+        height: 210px;
+    }
+
+    #dashRecommendedCarousel .carousel-item .user-card {
+        min-height: 210px;
+    }
+
+    #dashRecommendedCarousel .carousel-control-prev {
+        left: -40px;
+    }
+
+    #dashRecommendedCarousel .carousel-control-next {
+        right: -40px;
+    }
+}
+
+@media screen and (max-width: 650px) {
+    .dashboard-content {
+        padding: 40px 24px;
+        gap: 36px;
+    }
+
+    .dashboard-greeting {
+        font-size: 36px;
+    }
+
+    .search-bar-wrap {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .search-btn {
+        width: 100%;
+    }
+
+    .dash-section-header,
+    #dashRecommendedCarousel {
+        width: 100%;
+    }
+
+    #dashRecommendedCarousel .carousel-inner {
+        gap: 0;
+    }
+
+    #dashRecommendedCarousel .carousel-item {
+        flex: 0 0 100%;
+        max-width: 100%;
+    }
+
+    #dashRecommendedCarousel .carousel-item .user-card-wrap {
+        height: 210px;
+    }
+
+    #dashRecommendedCarousel .carousel-control-prev {
+        left: -18px;
+    }
+
+    #dashRecommendedCarousel .carousel-control-next {
+        right: -18px;
+    }
+}
+
+@media screen and (max-width: 360px) {
+    .dashboard-content {
+        padding: 32px 16px;
+    }
+
+    .dashboard-greeting {
+        font-size: 30px;
+    }
+
+    #dashRecommendedCarousel .carousel-item .user-card-wrap {
+        height: 200px;
+    }
+
+    #dashRecommendedCarousel .carousel-item .user-card {
+        min-height: 200px;
+        padding: 20px;
+    }
 }

--- a/web/static/css/dashboard.css
+++ b/web/static/css/dashboard.css
@@ -211,12 +211,6 @@
     position: relative;
 }
 
-.carousel-control-prev-icon {
-@media screen and (max-width: 900px){
-    .carousel-item{
-    flex: 0 0 calc((100%/2) - 40px);
-}
-}
 
 @media screen and (max-width: 650px){
     .carousel-item{

--- a/web/static/css/matching.css
+++ b/web/static/css/matching.css
@@ -5,8 +5,8 @@
     text-align: center;
     font-size: 16px;
     color: #888;
-    margin-top: -32px;
-    margin-bottom: 8px;
+    margin-top: -28px;
+    margin-bottom: -8px;
 }
 
 .matching-grid {
@@ -21,9 +21,9 @@
 .matching-empty {
     width: 100%;
     max-width: 760px;
-    margin: 24px auto 0;
+    margin: 8px auto 0;
     text-align: center;
-    padding: 56px 32px;
+    padding: 52px 32px;
     background: rgba(255, 255, 255, 0.86);
     border: 1px solid rgba(255, 149, 138, 0.18);
     border-radius: 28px;
@@ -39,14 +39,14 @@
     font-size: 28px;
     font-weight: 800;
     color: #F07060;
-    margin: 0 0 12px 0;
+    margin: 0 0 16px 0;
 }
 
 .matching-empty-subtitle {
     font-size: 16px;
-    color: #777;
+    color: #666;
     margin: 0 auto 28px;
-    max-width: 440px;
+    max-width: 520px;
     line-height: 1.5;
 }
 
@@ -165,7 +165,7 @@
 @media (max-width: 560px) {
     .matching-content {
         padding: 32px 18px !important;
-        gap: 24px !important;
+        gap: 32px !important;
     }
     .matching-content .dashboard-greeting { font-size: 28px !important; }
     .matching-content .matching-subtitle {

--- a/web/static/css/matching.css
+++ b/web/static/css/matching.css
@@ -16,6 +16,95 @@
 }
 
 /* =========================
+   EMPTY STATE (no matches yet)
+========================= */
+.matching-empty {
+    text-align: center;
+    padding: 60px 32px;
+    background: rgba(255, 255, 255, 0.74);
+    border-radius: 24px;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.07);
+}
+
+.matching-empty-icon {
+    font-size: 56px;
+    margin-bottom: 16px;
+}
+
+.matching-empty-title {
+    font-size: 26px;
+    font-weight: 800;
+    color: #333;
+    margin: 0 0 12px 0;
+}
+
+.matching-empty-subtitle {
+    font-size: 16px;
+    color: #666;
+    margin: 0 auto 28px;
+    max-width: 460px;
+    line-height: 1.5;
+}
+
+.quiz-cta-btn {
+    display: inline-block;
+    background: #FF958A;
+    color: white;
+    font-weight: 700;
+    font-size: 16px;
+    padding: 14px 36px;
+    border-radius: 30px;
+    text-decoration: none;
+    transition: background 0.2s, transform 0.15s;
+    box-shadow: 0 6px 16px rgba(255, 149, 138, 0.3);
+}
+
+.quiz-cta-btn:hover {
+    background: #F07066;
+    transform: translateY(-2px);
+    color: white;
+}
+
+/* =========================
+   PERSISTENT QUIZ CTA (shown when matches exist)
+========================= */
+.quiz-prompt {
+    text-align: center;
+    padding: 24px;
+    background: rgba(255, 255, 255, 0.5);
+    border-radius: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.quiz-prompt-text {
+    font-size: 16px;
+    color: #555;
+    margin: 0;
+    font-weight: 500;
+}
+
+.quiz-prompt-btn {
+    background: transparent;
+    color: #F28A80;
+    font-weight: 700;
+    font-size: 15px;
+    padding: 8px 20px;
+    border: 2px solid #F28A80;
+    border-radius: 30px;
+    text-decoration: none;
+    transition: all 0.2s;
+}
+
+.quiz-prompt-btn:hover {
+    background: #F28A80;
+    color: white;
+}
+
+/* =========================
    DASHBOARD: My Matches header
    (loaded in dashboard.html too)
 ========================= */
@@ -37,54 +126,44 @@
 
 /* =========================
    MATCHING PAGE — RESPONSIVE
-   (scoped to .matching-content so dashboard isn't affected)
+   (scoped to .matching-content)
 ========================= */
-
-/* Tablet & smaller (≤ 1024px) */
 @media (max-width: 1024px) {
     .matching-content {
         padding: 50px 40px !important;
         gap: 36px !important;
     }
-    .matching-content .dashboard-greeting {
-        font-size: 44px !important;
-    }
+    .matching-content .dashboard-greeting { font-size: 44px !important; }
     .matching-content .matching-grid {
         grid-template-columns: repeat(2, 1fr);
         gap: 20px;
     }
 }
 
-/* Small tablet / large mobile (≤ 768px) */
 @media (max-width: 768px) {
     .matching-content {
         padding: 40px 28px !important;
         gap: 28px !important;
     }
-    .matching-content .dashboard-greeting {
-        font-size: 36px !important;
-    }
+    .matching-content .dashboard-greeting { font-size: 36px !important; }
     .matching-content .matching-subtitle {
         font-size: 14px;
         margin-top: -20px;
     }
-    .matching-content .matching-grid {
-        gap: 16px;
-    }
-    .matching-content .user-card {
-        padding: 16px;
-    }
+    .matching-content .matching-grid { gap: 16px; }
+    .matching-content .user-card { padding: 16px; }
+    .matching-content .matching-empty { padding: 48px 24px; }
+    .matching-content .matching-empty-title { font-size: 22px; }
+    .matching-content .matching-empty-subtitle { font-size: 14px; }
+    .matching-content .matching-empty-icon { font-size: 44px; }
 }
 
-/* Mobile (≤ 560px) */
 @media (max-width: 560px) {
     .matching-content {
         padding: 32px 18px !important;
         gap: 24px !important;
     }
-    .matching-content .dashboard-greeting {
-        font-size: 28px !important;
-    }
+    .matching-content .dashboard-greeting { font-size: 28px !important; }
     .matching-content .matching-subtitle {
         font-size: 13px;
         margin-top: -16px;
@@ -93,24 +172,92 @@
         grid-template-columns: 1fr;
         gap: 14px;
     }
-    .matching-content .user-card-name {
-        font-size: 15px;
-    }
-    .matching-content .user-card-bio {
-        font-size: 13px;
-    }
-    .matching-content .heart-btn {
-        font-size: 24px;
-        padding: 6px;
-    }
+    .matching-content .user-card-name { font-size: 15px; }
+    .matching-content .user-card-bio { font-size: 13px; }
+    .matching-content .matching-empty { padding: 40px 18px; }
+    .matching-content .quiz-cta-btn { padding: 12px 28px; font-size: 14px; }
+    .matching-content .quiz-prompt { padding: 18px; gap: 12px; }
+    .matching-content .quiz-prompt-text { font-size: 14px; }
 }
 
-/* Tiny mobile (≤ 360px) */
 @media (max-width: 360px) {
     .matching-content {
         padding: 24px 14px !important;
     }
-    .matching-content .dashboard-greeting {
-        font-size: 24px !important;
-    }
+    .matching-content .dashboard-greeting { font-size: 24px !important; }
+}
+
+/* =========================
+   EMPTY STATE + QUIZ CTA
+========================= */
+.matching-empty {
+    text-align: center;
+    padding: 60px 24px;
+    background: #f5cebc;
+    border-radius: 24px;
+}
+
+.matching-empty-title {
+    font-size: 26px;
+    font-weight: 700;
+    color: #c04030;
+    margin: 0 0 8px 0;
+}
+
+.matching-empty-subtitle {
+    font-size: 16px;
+    color: #885a4a;
+    margin: 0 0 24px 0;
+}
+
+.quiz-cta-btn {
+    display: inline-block;
+    background: #FF958A;
+    color: white;
+    font-weight: 700;
+    font-size: 16px;
+    padding: 14px 36px;
+    border-radius: 30px;
+    text-decoration: none;
+    transition: background 0.2s, transform 0.2s;
+    box-shadow: 0 4px 14px rgba(255, 149, 138, 0.3);
+}
+
+.quiz-cta-btn:hover {
+    background: #F07066;
+    color: white;
+    transform: translateY(-2px);
+}
+
+/* Persistent CTA shown when matches exist */
+.quiz-cta-footer {
+    text-align: center;
+    padding: 20px;
+    background: rgba(245, 206, 188, 0.5);
+    border-radius: 16px;
+    margin-top: 16px;
+}
+
+.quiz-cta-footer p {
+    margin: 0 0 4px 0;
+    color: #885a4a;
+    font-size: 14px;
+}
+
+.quiz-cta-link {
+    color: #F28A80;
+    font-weight: 700;
+    text-decoration: none;
+    font-size: 15px;
+    transition: color 0.2s;
+}
+
+.quiz-cta-link:hover { color: #F07066; }
+
+/* Responsive overrides */
+@media (max-width: 560px) {
+    .matching-content .matching-empty { padding: 40px 18px; }
+    .matching-content .matching-empty-title { font-size: 22px; }
+    .matching-content .matching-empty-subtitle { font-size: 14px; }
+    .matching-content .quiz-cta-btn { padding: 12px 28px; font-size: 14px; }
 }

--- a/web/static/css/matching.css
+++ b/web/static/css/matching.css
@@ -19,11 +19,15 @@
    EMPTY STATE (no matches yet)
 ========================= */
 .matching-empty {
+    width: 100%;
+    max-width: 760px;
+    margin: 24px auto 0;
     text-align: center;
-    padding: 60px 32px;
-    background: rgba(255, 255, 255, 0.74);
-    border-radius: 24px;
-    box-shadow: 0 4px 16px rgba(0,0,0,0.07);
+    padding: 56px 32px;
+    background: rgba(255, 255, 255, 0.86);
+    border: 1px solid rgba(255, 149, 138, 0.18);
+    border-radius: 28px;
+    box-shadow: 0 8px 24px rgba(240, 112, 96, 0.10);
 }
 
 .matching-empty-icon {
@@ -32,17 +36,17 @@
 }
 
 .matching-empty-title {
-    font-size: 26px;
+    font-size: 28px;
     font-weight: 800;
-    color: #333;
+    color: #F07060;
     margin: 0 0 12px 0;
 }
 
 .matching-empty-subtitle {
     font-size: 16px;
-    color: #666;
+    color: #777;
     margin: 0 auto 28px;
-    max-width: 460px;
+    max-width: 440px;
     line-height: 1.5;
 }
 
@@ -185,48 +189,6 @@
         padding: 24px 14px !important;
     }
     .matching-content .dashboard-greeting { font-size: 24px !important; }
-}
-
-/* =========================
-   EMPTY STATE + QUIZ CTA
-========================= */
-.matching-empty {
-    text-align: center;
-    padding: 60px 24px;
-    background: #f5cebc;
-    border-radius: 24px;
-}
-
-.matching-empty-title {
-    font-size: 26px;
-    font-weight: 700;
-    color: #c04030;
-    margin: 0 0 8px 0;
-}
-
-.matching-empty-subtitle {
-    font-size: 16px;
-    color: #885a4a;
-    margin: 0 0 24px 0;
-}
-
-.quiz-cta-btn {
-    display: inline-block;
-    background: #FF958A;
-    color: white;
-    font-weight: 700;
-    font-size: 16px;
-    padding: 14px 36px;
-    border-radius: 30px;
-    text-decoration: none;
-    transition: background 0.2s, transform 0.2s;
-    box-shadow: 0 4px 14px rgba(255, 149, 138, 0.3);
-}
-
-.quiz-cta-btn:hover {
-    background: #F07066;
-    color: white;
-    transform: translateY(-2px);
 }
 
 /* Persistent CTA shown when matches exist */

--- a/web/static/css/matching.css
+++ b/web/static/css/matching.css
@@ -1,0 +1,43 @@
+/* =========================
+   MATCHING PAGE
+========================= */
+.matching-subtitle {
+    text-align: center;
+    font-size: 16px;
+    color: #888;
+    margin-top: -32px;
+    margin-bottom: 8px;
+}
+
+.matching-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 24px;
+}
+
+@media (max-width: 900px) {
+    .matching-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 600px) {
+    .matching-grid { grid-template-columns: 1fr; }
+}
+
+/* =========================
+   DASHBOARD: My Matches header
+   (loaded in dashboard.html too)
+========================= */
+.dash-section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+}
+
+.view-more-link {
+    font-size: 14px;
+    font-weight: 700;
+    color: #F28A80;
+    text-decoration: none;
+    transition: color 0.2s;
+}
+
+.view-more-link:hover { color: #F07066; }

--- a/web/static/css/matching.css
+++ b/web/static/css/matching.css
@@ -15,13 +15,6 @@
     gap: 24px;
 }
 
-@media (max-width: 900px) {
-    .matching-grid { grid-template-columns: repeat(2, 1fr); }
-}
-@media (max-width: 600px) {
-    .matching-grid { grid-template-columns: 1fr; }
-}
-
 /* =========================
    DASHBOARD: My Matches header
    (loaded in dashboard.html too)
@@ -41,3 +34,83 @@
 }
 
 .view-more-link:hover { color: #F07066; }
+
+/* =========================
+   MATCHING PAGE — RESPONSIVE
+   (scoped to .matching-content so dashboard isn't affected)
+========================= */
+
+/* Tablet & smaller (≤ 1024px) */
+@media (max-width: 1024px) {
+    .matching-content {
+        padding: 50px 40px !important;
+        gap: 36px !important;
+    }
+    .matching-content .dashboard-greeting {
+        font-size: 44px !important;
+    }
+    .matching-content .matching-grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 20px;
+    }
+}
+
+/* Small tablet / large mobile (≤ 768px) */
+@media (max-width: 768px) {
+    .matching-content {
+        padding: 40px 28px !important;
+        gap: 28px !important;
+    }
+    .matching-content .dashboard-greeting {
+        font-size: 36px !important;
+    }
+    .matching-content .matching-subtitle {
+        font-size: 14px;
+        margin-top: -20px;
+    }
+    .matching-content .matching-grid {
+        gap: 16px;
+    }
+    .matching-content .user-card {
+        padding: 16px;
+    }
+}
+
+/* Mobile (≤ 560px) */
+@media (max-width: 560px) {
+    .matching-content {
+        padding: 32px 18px !important;
+        gap: 24px !important;
+    }
+    .matching-content .dashboard-greeting {
+        font-size: 28px !important;
+    }
+    .matching-content .matching-subtitle {
+        font-size: 13px;
+        margin-top: -16px;
+    }
+    .matching-content .matching-grid {
+        grid-template-columns: 1fr;
+        gap: 14px;
+    }
+    .matching-content .user-card-name {
+        font-size: 15px;
+    }
+    .matching-content .user-card-bio {
+        font-size: 13px;
+    }
+    .matching-content .heart-btn {
+        font-size: 24px;
+        padding: 6px;
+    }
+}
+
+/* Tiny mobile (≤ 360px) */
+@media (max-width: 360px) {
+    .matching-content {
+        padding: 24px 14px !important;
+    }
+    .matching-content .dashboard-greeting {
+        font-size: 24px !important;
+    }
+}

--- a/web/templates/main/dashboard.html
+++ b/web/templates/main/dashboard.html
@@ -42,7 +42,10 @@
             <a href="{{ url_for('quizzes.quizzes_page') }}" class="search-btn" style="font-size: 20px; margin-left: 100px; margin-right: 100px; text-decoration: none; display: inline-block;">Take a quiz</a>
         {% else %}
 
-        <h2 class="dash-section-title">Recommended</h2>
+        <div class="dash-section-header">
+            <h2 class="dash-section-title">My Matches</h2>
+            <a href="{{ url_for('main.matching') }}" class="view-more-link">View more →</a>
+        </div>
         
         <div id="dashRecommendedCarousel" class="carousel" data-ride="carousel" data-wrap="false" style="width: 90%; align-self: center;">
 

--- a/web/templates/main/dashboard.html
+++ b/web/templates/main/dashboard.html
@@ -47,7 +47,7 @@
             <a href="{{ url_for('main.matching') }}" class="view-more-link">View more →</a>
         </div>
         
-        <div id="dashRecommendedCarousel" class="carousel" data-ride="carousel" data-wrap="false" style="width: 90%; align-self: center;">
+        <div id="dashRecommendedCarousel" class="carousel" data-ride="carousel" data-wrap="false">
 
             <div class="carousel-inner">
 
@@ -80,11 +80,10 @@
             </div>
             <a class="carousel-control-prev" href="#dashRecommendedCarousel" role="button" data-slide="prev">
                 <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-
             </a>
+            
             <a class="carousel-control-next" href="#dashRecommendedCarousel" role="button" data-slide="next">
                 <span class="carousel-control-next-icon" aria-hidden="true"></span>
-
             </a>
         </div>
         {% endif %}

--- a/web/templates/main/dashboard.html
+++ b/web/templates/main/dashboard.html
@@ -5,6 +5,7 @@
 
 {% block styles %}
     <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/matching.css') }}">
 {% endblock %}
 
 {% block content %}
@@ -30,7 +31,10 @@
 
     <!-- RECOMMENDED -->
     <section class="dash-section">
-        <h2 class="dash-section-title">Recommended</h2>
+        <div class="dash-section-header">
+            <h2 class="dash-section-title">My Matches</h2>
+            <a href="{{ url_for('main.matching') }}" class="view-more-link">View more →</a>
+        </div>
         <div class="card-slider-wrap">
             <button class="slider-arrow left">&#9664;</button>
             <div class="card-row">

--- a/web/templates/main/dashboard.html
+++ b/web/templates/main/dashboard.html
@@ -78,11 +78,11 @@
                 {% endfor %}
                 
             </div>
-            <a class="carousel-control-prev" href="#recommendedCarousel" role="button" data-slide="prev">
+            <a class="carousel-control-prev" href="#dashRecommendedCarousel" role="button" data-slide="prev">
                 <span class="carousel-control-prev-icon" aria-hidden="true"></span>
 
             </a>
-            <a class="carousel-control-next" href="#recommendedCarousel" role="button" data-slide="next">
+            <a class="carousel-control-next" href="#dashRecommendedCarousel" role="button" data-slide="next">
                 <span class="carousel-control-next-icon" aria-hidden="true"></span>
 
             </a>

--- a/web/templates/main/matching.html
+++ b/web/templates/main/matching.html
@@ -13,7 +13,7 @@
 
     <h1 class="dashboard-greeting">My Matches</h1>
 
-    <p class="matching-subtitle">Browse all your matched study partners</p>
+    <p class="matching-subtitle">People who match your vibe</p>
 
     <div class="matching-grid">
         {% for i in range(9) %}

--- a/web/templates/main/matching.html
+++ b/web/templates/main/matching.html
@@ -9,11 +9,10 @@
 {% endblock %}
 
 {% block content %}
-<div class="dashboard-content">
+<div class="dashboard-content matching-content">
 
     <h1 class="dashboard-greeting">My Matches</h1>
-
-    <p class="matching-subtitle">People who match your vibe</p>
+    <p class="matching-subtitle">People who match your vibe ✨</p>
 
     <div class="matching-grid">
         {% for i in range(9) %}

--- a/web/templates/main/matching.html
+++ b/web/templates/main/matching.html
@@ -12,7 +12,7 @@
 <div class="dashboard-content matching-content">
 
     <h1 class="dashboard-greeting">My Matches</h1>
-    <p class="matching-subtitle">People who match your vibe ✨</p>
+    <p class="matching-subtitle">Find study partners based on your quiz answers !</p>
 
     {% if not matches or matches|length == 0 %}
         <!-- EMPTY STATE: No matches yet -->

--- a/web/templates/main/matching.html
+++ b/web/templates/main/matching.html
@@ -14,15 +14,24 @@
     <h1 class="dashboard-greeting">My Matches</h1>
     <p class="matching-subtitle">Find study partners based on your quiz answers</p>
 
-    {% if not matches or matches|length == 0 %}
-        <!-- EMPTY STATE: No matches yet -->
+    {% if not has_quizzes %}
+        <!-- STATE 1: User hasn't taken any quizzes yet -->
         <div class="matching-empty">
             <p class="matching-empty-title">No matches yet</p>
             <p class="matching-empty-subtitle">Take a quiz to find study partners who match your vibe!</p>
             <a href="{{ url_for('quizzes.quizzes_page') }}" class="quiz-cta-btn">Take a quiz</a>
         </div>
+
+    {% elif not matches or matches|length == 0 %}
+        <!-- STATE 2: User has taken quizzes but no matches found -->
+        <div class="matching-empty">
+            <p class="matching-empty-title">No matches found yet</p>
+            <p class="matching-empty-subtitle">We couldn't find study partners that match your quiz answers yet. Try taking more quizzes — new users join every day!</p>
+            <a href="{{ url_for('quizzes.quizzes_page') }}" class="quiz-cta-btn">Take more quizzes</a>
+        </div>
+
     {% else %}
-        <!-- MATCH RESULTS -->
+        <!-- STATE 3: User has matches -->
         <div class="matching-grid">
             {% for match in matches %}
             <div class="user-card-wrap">
@@ -46,7 +55,7 @@
             {% endfor %}
         </div>
 
-        <!-- Persistent CTA -->
+        <!-- Persistent CTA when matches exist -->
         <div class="quiz-cta-footer">
             <p>Want more matches?</p>
             <a href="{{ url_for('quizzes.quizzes_page') }}" class="quiz-cta-link">Take more quizzes →</a>

--- a/web/templates/main/matching.html
+++ b/web/templates/main/matching.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% block wrapper_class %}profile-page{% endblock %}
+
+{% block title %}My Matches{% endblock %}
+
+{% block styles %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/matching.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="dashboard-content">
+
+    <h1 class="dashboard-greeting">My Matches</h1>
+
+    <p class="matching-subtitle">Browse all your matched study partners</p>
+
+    <div class="matching-grid">
+        {% for i in range(9) %}
+        <div class="user-card">
+            <div class="user-card-header">
+                <div class="user-card-avatar" style="background: {{ ['#F28A80','#FFB75C','#e07070'][i % 3] }}">?</div>
+                <span class="user-card-name">Name Lastname</span>
+            </div>
+            <div class="user-card-tags">
+                <span class="user-tag" style="background:#FFB75C"></span>
+                <span class="user-tag" style="background:#F28A80"></span>
+                <span class="user-tag" style="background:#e8a060"></span>
+            </div>
+            <p class="user-card-bio">Short bio that is around a sentence long.</p>
+            <button class="heart-btn">♡</button>
+        </div>
+        {% endfor %}
+    </div>
+
+    <a href="{{ url_for('main.dashboard') }}" class="cancel-link" style="text-align:center; display:block; margin-top:20px;">← Back to Dashboard</a>
+
+</div>
+{% endblock %}

--- a/web/templates/main/matching.html
+++ b/web/templates/main/matching.html
@@ -12,13 +12,13 @@
 <div class="dashboard-content matching-content">
 
     <h1 class="dashboard-greeting">My Matches</h1>
-    <p class="matching-subtitle">Find study partners based on your quiz answers !</p>
+    <p class="matching-subtitle">Find study partners based on your quiz answers</p>
 
     {% if not matches or matches|length == 0 %}
         <!-- EMPTY STATE: No matches yet -->
         <div class="matching-empty">
             <p class="matching-empty-title">No matches yet</p>
-            <p class="matching-empty-subtitle">Take some quizzes so we can find study partners that match your vibe!</p>
+            <p class="matching-empty-subtitle">TTake a quiz to find study partners who match your vibe!</p>
             <a href="{{ url_for('quizzes.quizzes_page') }}" class="quiz-cta-btn">Take a quiz</a>
         </div>
     {% else %}

--- a/web/templates/main/matching.html
+++ b/web/templates/main/matching.html
@@ -18,7 +18,7 @@
         <!-- EMPTY STATE: No matches yet -->
         <div class="matching-empty">
             <p class="matching-empty-title">No matches yet</p>
-            <p class="matching-empty-subtitle">TTake a quiz to find study partners who match your vibe!</p>
+            <p class="matching-empty-subtitle">Take a quiz to find study partners who match your vibe!</p>
             <a href="{{ url_for('quizzes.quizzes_page') }}" class="quiz-cta-btn">Take a quiz</a>
         </div>
     {% else %}

--- a/web/templates/main/matching.html
+++ b/web/templates/main/matching.html
@@ -14,23 +14,44 @@
     <h1 class="dashboard-greeting">My Matches</h1>
     <p class="matching-subtitle">People who match your vibe ✨</p>
 
-    <div class="matching-grid">
-        {% for i in range(9) %}
-        <div class="user-card">
-            <div class="user-card-header">
-                <div class="user-card-avatar" style="background: {{ ['#F28A80','#FFB75C','#e07070'][i % 3] }}">?</div>
-                <span class="user-card-name">Name Lastname</span>
-            </div>
-            <div class="user-card-tags">
-                <span class="user-tag" style="background:#FFB75C"></span>
-                <span class="user-tag" style="background:#F28A80"></span>
-                <span class="user-tag" style="background:#e8a060"></span>
-            </div>
-            <p class="user-card-bio">Short bio that is around a sentence long.</p>
-            <button class="heart-btn">♡</button>
+    {% if not matches or matches|length == 0 %}
+        <!-- EMPTY STATE: No matches yet -->
+        <div class="matching-empty">
+            <p class="matching-empty-title">No matches yet</p>
+            <p class="matching-empty-subtitle">Take some quizzes so we can find study partners that match your vibe!</p>
+            <a href="{{ url_for('quizzes.quizzes_page') }}" class="quiz-cta-btn">Take a quiz</a>
         </div>
-        {% endfor %}
-    </div>
+    {% else %}
+        <!-- MATCH RESULTS -->
+        <div class="matching-grid">
+            {% for match in matches %}
+            <div class="user-card-wrap">
+                <a href="{{ url_for('main.view_user', username=match.username) }}" class="user-card">
+                    <div class="user-card-header">
+                        <div class="user-card-avatar" style="background: {{ (['#FE9900','#FFBC57','#FFB697','#F79181','#ED553D']*4)[loop.index0] }}">
+                            {{ match.displayname[0] | upper }}
+                        </div>
+                        <span class="user-card-name">{{ match.displayname }}</span>
+                    </div>
+                    <p class="user-card-bio">
+                        {{ match.bio_entry.bio_text if match.bio_entry and match.bio_entry.bio_text else 'No bio added yet.' }}
+                    </p>
+                </a>
+                <button class="heart-btn {% if match.username in liked_usernames %}liked{% endif %}"
+                        type="button" data-username="{{ match.username }}"
+                        data-liked="{{ 'true' if match.username in liked_usernames else 'false' }}">
+                    {{ '♥' if match.username in liked_usernames else '♡' }}
+                </button>
+            </div>
+            {% endfor %}
+        </div>
+
+        <!-- Persistent CTA -->
+        <div class="quiz-cta-footer">
+            <p>Want more matches?</p>
+            <a href="{{ url_for('quizzes.quizzes_page') }}" class="quiz-cta-link">Take more quizzes →</a>
+        </div>
+    {% endif %}
 
     <a href="{{ url_for('main.dashboard') }}" class="cancel-link" style="text-align:center; display:block; margin-top:20px;">← Back to Dashboard</a>
 

--- a/web/templates/main/matching.html
+++ b/web/templates/main/matching.html
@@ -54,6 +54,5 @@
     {% endif %}
 
     <a href="{{ url_for('main.dashboard') }}" class="cancel-link" style="text-align:center; display:block; margin-top:20px;">← Back to Dashboard</a>
-
 </div>
 {% endblock %}


### PR DESCRIPTION
- Renamed "Recommended" section on dashboard to "My Matches" with a "View more →" link
- Created /matches route and matching.html page showing matched profiles in a 3-column responsive grid
- Created matching.css for matching page-specific styles
- Reuses existing user-card styles from dashboard.css
- Matching logic is not yet connected — placeholder 9 cards are rendered for now
- Quiz result page integration/link will be added later once the quiz page UI is finalized